### PR TITLE
Ssuto 70 refactor user profile form to be reactive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,25 @@
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-xml</artifactId>
     </dependency>
+
+    <!-- SECURITY DEPENDENCIES -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+
+    <!-- https://mvnrepository.com/artifact/com.auth0/java-jwt -->
+    <dependency>
+      <groupId>com.auth0</groupId>
+      <artifactId>java-jwt</artifactId>
+      <version>3.11.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-test</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/src/main/java/com/ss/utopia/customer/bootstrap/H2DataBootstrap.java
+++ b/src/main/java/com/ss/utopia/customer/bootstrap/H2DataBootstrap.java
@@ -1,0 +1,50 @@
+package com.ss.utopia.customer.bootstrap;
+
+import com.ss.utopia.customer.entity.Address;
+import com.ss.utopia.customer.entity.Customer;
+import com.ss.utopia.customer.repository.CustomerRepository;
+import java.util.Collections;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("local-h2")
+@RequiredArgsConstructor
+public class H2DataBootstrap implements CommandLineRunner {
+
+  private final CustomerRepository customerRepository;
+
+  @Override
+  public void run(String... args) throws Exception {
+    if (customerRepository.count() == 0) {
+      loadAllCustomerAccounts();
+    }
+  }
+
+  private void loadAllCustomerAccounts() {
+    loadCustomer1();
+  }
+
+  private void loadCustomer1() {
+    var customer = Customer.builder()
+        .email("john_sample@example.com")
+        .firstName("John")
+        .lastName("Sample")
+        .loyaltyPoints(0)
+        .phoneNumber("999-999-9999")
+        .addresses(Set.of(Address.builder()
+                              .cardinality(1)
+                              .line1("2 Electric Ave.")
+                              .line2("Suite HI-R")
+                              .city("Las Vegas")
+                              .state("NV")
+                              .zipcode("69420")
+                              .build()))
+        .paymentMethods(Collections.emptySet())
+        .build();
+    customerRepository.save(customer);
+  }
+}

--- a/src/main/java/com/ss/utopia/customer/controller/CustomerController.java
+++ b/src/main/java/com/ss/utopia/customer/controller/CustomerController.java
@@ -3,6 +3,7 @@ package com.ss.utopia.customer.controller;
 import com.ss.utopia.customer.dto.CreateCustomerDto;
 import com.ss.utopia.customer.dto.PaymentMethodDto;
 import com.ss.utopia.customer.dto.UpdateCustomerDto;
+import com.ss.utopia.customer.dto.UpdateCustomerLoyaltyDto;
 import com.ss.utopia.customer.entity.Customer;
 import com.ss.utopia.customer.entity.PaymentMethod;
 import com.ss.utopia.customer.security.permissions.CreateCustomerPermission;
@@ -71,6 +72,16 @@ public class CustomerController {
   public ResponseEntity<Integer> getCustomerLoyaltyPoints(@PathVariable UUID customerId) {
     log.info("GET Customer Loyalty Points when Customer id=" + customerId);
     return ResponseEntity.of(Optional.ofNullable(service.getCustomerLoyaltyPoints(customerId)));
+  }
+  
+  @PreAuthorize("hasAnyRole('ADMIN','EMPLOYEE','TRAVEL_AGENT')")
+  @PutMapping(value = "/loyalty/{customerId}",
+		  consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+  public ResponseEntity<?> updateCustomerloyaltyPoints(@PathVariable UUID customerId,
+		  						@Valid @RequestBody UpdateCustomerLoyaltyDto customerLoyaltyDto) {
+	  log.info("PUT Update Customer loyalty points when Customer ID=" + customerId);
+	  service.updateCustomerLoyaltyPoints(customerId, customerLoyaltyDto);
+	  return ResponseEntity.ok().build();
   }
 
   @CreateCustomerPermission

--- a/src/main/java/com/ss/utopia/customer/controller/CustomerController.java
+++ b/src/main/java/com/ss/utopia/customer/controller/CustomerController.java
@@ -5,6 +5,10 @@ import com.ss.utopia.customer.dto.PaymentMethodDto;
 import com.ss.utopia.customer.dto.UpdateCustomerDto;
 import com.ss.utopia.customer.entity.Customer;
 import com.ss.utopia.customer.entity.PaymentMethod;
+import com.ss.utopia.customer.security.permissions.CreateCustomerPermission;
+import com.ss.utopia.customer.security.permissions.DeleteCustomerByIdPermission;
+import com.ss.utopia.customer.security.permissions.GetCustomerByEmailPermission;
+import com.ss.utopia.customer.security.permissions.GetCustomerByIdPermission;
 import com.ss.utopia.customer.service.CustomerService;
 import java.net.URI;
 import java.util.List;
@@ -15,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -33,6 +38,7 @@ public class CustomerController {
   private static final String MAPPING = EndpointConstants.API_V_0_1_CUSTOMERS;
   private final CustomerService service;
 
+  @PreAuthorize("hasRole('ADMIN')")
   @GetMapping(produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
   public ResponseEntity<List<Customer>> getAllCustomers() {
     log.info("GET Customer all");
@@ -43,20 +49,31 @@ public class CustomerController {
     return ResponseEntity.ok(customers);
   }
 
-  @GetMapping(value = "/{id}", produces = {MediaType.APPLICATION_JSON_VALUE,
-      MediaType.APPLICATION_XML_VALUE})
-  public ResponseEntity<Customer> getCustomerById(@PathVariable UUID id) {
-    log.info("GET Customer id=" + id);
-    return ResponseEntity.of(Optional.ofNullable(service.getCustomerById(id)));
+  @GetCustomerByIdPermission
+  @GetMapping(value = "/{customerId}",
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+  public ResponseEntity<Customer> getCustomerById(@PathVariable UUID customerId) {
+    log.info("GET Customer id=" + customerId);
+    return ResponseEntity.of(Optional.ofNullable(service.getCustomerById(customerId)));
   }
 
-  @GetMapping(value = "/loyalty/{id}", produces = {MediaType.APPLICATION_JSON_VALUE,
-      MediaType.APPLICATION_XML_VALUE})
-  public ResponseEntity<Integer> getCustomerLoyaltyPoints(@PathVariable UUID id) {
-    log.info("GET Customer Loyalty Points when Customer id=" + id);
-    return ResponseEntity.of(Optional.ofNullable(service.getCustomerLoyaltyPoints(id)));
+  @GetCustomerByEmailPermission
+  @GetMapping(value = "/email/{email}",
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+  public ResponseEntity<Customer> getCustomerByEmail(@PathVariable String email) {
+    log.info("GET Customer email=" + email);
+    return ResponseEntity.of(Optional.ofNullable(service.getCustomerByEmail(email)));
   }
 
+  @GetCustomerByIdPermission
+  @GetMapping(value = "/loyalty/{customerId}",
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
+  public ResponseEntity<Integer> getCustomerLoyaltyPoints(@PathVariable UUID customerId) {
+    log.info("GET Customer Loyalty Points when Customer id=" + customerId);
+    return ResponseEntity.of(Optional.ofNullable(service.getCustomerLoyaltyPoints(customerId)));
+  }
+
+  @CreateCustomerPermission
   @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
   public ResponseEntity<Customer> createNewCustomer(@Valid @RequestBody CreateCustomerDto customerDto) {
     log.info("POST Customer");
@@ -67,22 +84,25 @@ public class CustomerController {
 
   //todo DTO should be updated to allow multiple addresses (or a new one created).
   // Additionally, any field not present should not cause an error and should instead just not be modified.
-  @PutMapping(value = "/{id}",
+  @GetCustomerByIdPermission
+  @PutMapping(value = "/{customerId}",
       consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
-  public ResponseEntity<?> updateExistingCustomer(@PathVariable UUID id,
+  public ResponseEntity<?> updateExistingCustomer(@PathVariable UUID customerId,
                                                   @Valid @RequestBody UpdateCustomerDto updateCustomerDto) {
-    log.info("PUT Customer id=" + id);
-    service.updateCustomer(id, updateCustomerDto);
+    log.info("PUT Customer id=" + customerId);
+    service.updateCustomer(customerId, updateCustomerDto);
     return ResponseEntity.noContent().build();
   }
 
-  @DeleteMapping("/{id}")
-  public ResponseEntity<String> deleteCustomer(@PathVariable UUID id) {
-    log.info("DELETE id=" + id);
-    service.removeCustomerById(id);
+  @DeleteCustomerByIdPermission
+  @DeleteMapping("/{customerId}")
+  public ResponseEntity<String> deleteCustomer(@PathVariable UUID customerId) {
+    log.info("DELETE id=" + customerId);
+    service.removeCustomerById(customerId);
     return ResponseEntity.noContent().build();
   }
 
+  @GetCustomerByIdPermission
   @GetMapping(value = "/{customerId}/payment-method/{paymentId}",
       produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
   public ResponseEntity<PaymentMethod> getPaymentMethod(@PathVariable UUID customerId,
@@ -91,16 +111,18 @@ public class CustomerController {
     return ResponseEntity.of(Optional.of(service.getPaymentMethod(customerId, paymentId)));
   }
 
-  @PostMapping(value = "/{id}/payment-method",
+  @GetCustomerByIdPermission
+  @PostMapping(value = "/{customerId}/payment-method",
       consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
-  public ResponseEntity<?> addPaymentMethod(@PathVariable UUID id,
+  public ResponseEntity<?> addPaymentMethod(@PathVariable UUID customerId,
                                             @Valid @RequestBody PaymentMethodDto paymentMethodDto) {
-    log.info("POST PaymentMethod id=" + id);
-    var paymentId = service.addPaymentMethod(id, paymentMethodDto);
-    var uri = URI.create(MAPPING + "/" + id + "/payment-method/" + paymentId);
+    log.info("POST PaymentMethod id=" + customerId);
+    var paymentId = service.addPaymentMethod(customerId, paymentMethodDto);
+    var uri = URI.create(MAPPING + "/" + customerId + "/payment-method/" + paymentId);
     return ResponseEntity.created(uri).build();
   }
 
+  @GetCustomerByIdPermission
   @PutMapping(value = "/{customerId}/payment-method/{paymentId}",
       consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
   public ResponseEntity<?> updatePaymentMethod(@PathVariable UUID customerId,
@@ -111,6 +133,7 @@ public class CustomerController {
     return ResponseEntity.noContent().build();
   }
 
+  @DeleteCustomerByIdPermission
   @DeleteMapping("/{customerId}/payment-method/{paymentId}")
   public ResponseEntity<?> removePaymentMethod(@PathVariable UUID customerId,
                                                @PathVariable Long paymentId) {

--- a/src/main/java/com/ss/utopia/customer/dto/UpdateCustomerDto.java
+++ b/src/main/java/com/ss/utopia/customer/dto/UpdateCustomerDto.java
@@ -1,7 +1,6 @@
 package com.ss.utopia.customer.dto;
 
 import javax.validation.constraints.Email;
-import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
@@ -21,9 +20,6 @@ public class UpdateCustomerDto {
 
   @NotBlank(message = "Last name is mandatory")
   private String lastName;
-
-  @Min(0)
-  private Integer loyaltyPoints;
 
   @NotBlank
   @Email(message = "Email is invalid")

--- a/src/main/java/com/ss/utopia/customer/dto/UpdateCustomerDto.java
+++ b/src/main/java/com/ss/utopia/customer/dto/UpdateCustomerDto.java
@@ -29,6 +29,9 @@ public class UpdateCustomerDto {
   @Email(message = "Email is invalid")
   private String email;
 
+  @Pattern(regexp = "^\\d{3}-\\d{3}-\\d{4}$", message = "Phone number must be in the form ###-###-####.")
+  private String phoneNumber;
+
   @NotBlank(message = "Address line1 is mandatory")
   private String addrLine1;
 

--- a/src/main/java/com/ss/utopia/customer/dto/UpdateCustomerLoyaltyDto.java
+++ b/src/main/java/com/ss/utopia/customer/dto/UpdateCustomerLoyaltyDto.java
@@ -1,0 +1,24 @@
+package com.ss.utopia.customer.dto;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateCustomerLoyaltyDto {
+	
+	@NotNull
+	@Min(1)
+	private Integer pointsToChange;
+	
+	@NotNull
+	private Boolean increment;
+}

--- a/src/main/java/com/ss/utopia/customer/exception/ExceptionControllerAdvisor.java
+++ b/src/main/java/com/ss/utopia/customer/exception/ExceptionControllerAdvisor.java
@@ -90,6 +90,17 @@ public class ExceptionControllerAdvisor {
     response.put("message", errors);
     return response;
   }
+  
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(IllegalPointChangeException.class)
+  public Map<String, Object> handleIllegalPointChangeExceptions(IllegalPointChangeException ex) {
+	  LOGGER.error(ex.getMessage());
+	  
+	  var response = new HashMap<String, Object>();
+	  response.put("error", ex.getMessage());
+	  response.put("status", 400);
+	  return response;
+  }
 
   /**
    * Helper function to get error message or provide a default if not present.

--- a/src/main/java/com/ss/utopia/customer/exception/IllegalPointChangeException.java
+++ b/src/main/java/com/ss/utopia/customer/exception/IllegalPointChangeException.java
@@ -1,0 +1,22 @@
+package com.ss.utopia.customer.exception;
+
+import java.util.UUID;
+
+import lombok.Getter;
+
+public class IllegalPointChangeException extends IllegalStateException {
+	
+	@Getter
+	final private UUID customerId;
+	@Getter
+	final private Integer currentPoints;
+	@Getter
+	final private Integer attemptedDelta;
+	
+	public IllegalPointChangeException(UUID customerId, Integer currentPoints, Integer attemptedDelta) {
+		super("Couldn't change points of customer " + customerId + " by " + attemptedDelta + "! Customer has " + currentPoints + ".");
+		this.customerId = customerId;
+		this.currentPoints = currentPoints;
+		this.attemptedDelta = attemptedDelta;
+	}
+}

--- a/src/main/java/com/ss/utopia/customer/exception/NoSuchCustomerException.java
+++ b/src/main/java/com/ss/utopia/customer/exception/NoSuchCustomerException.java
@@ -1,6 +1,7 @@
 package com.ss.utopia.customer.exception;
 
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -11,13 +12,25 @@ import java.util.UUID;
 public class NoSuchCustomerException extends NoSuchElementException {
 
   private final UUID customerId;
+  private final String customerEmail;
 
   public NoSuchCustomerException(UUID id) {
     super("No customer record found for id=" + id);
     this.customerId = id;
+    this.customerEmail = null;
   }
 
-  public UUID getCustomerId() {
-    return customerId;
+  public NoSuchCustomerException(String email) {
+    super("No customer record found for email=" + email);
+    this.customerEmail = email;
+    this.customerId = null;
+  }
+
+  public Optional<UUID> getCustomerId() {
+    return Optional.ofNullable(customerId);
+  }
+
+  public Optional<String> getCustomerEmail() {
+    return Optional.ofNullable(customerEmail);
   }
 }

--- a/src/main/java/com/ss/utopia/customer/security/CustomerAuthenticationManager.java
+++ b/src/main/java/com/ss/utopia/customer/security/CustomerAuthenticationManager.java
@@ -1,0 +1,21 @@
+package com.ss.utopia.customer.security;
+
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CustomerAuthenticationManager {
+
+  public boolean customerEmailMatches(Authentication authentication, String email) {
+    var authedEmail = (String) authentication.getPrincipal();
+    return authedEmail.equals(email);
+  }
+
+  public boolean customerIdMatches(Authentication authentication, UUID id) {
+    var jwtOwnerId = UUID.fromString((String)authentication.getDetails());
+    return jwtOwnerId.equals(id);
+  }
+}

--- a/src/main/java/com/ss/utopia/customer/security/JwtAuthenticationVerificationFilter.java
+++ b/src/main/java/com/ss/utopia/customer/security/JwtAuthenticationVerificationFilter.java
@@ -1,0 +1,81 @@
+package com.ss.utopia.customer.security;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import java.io.IOException;
+import java.util.stream.Collectors;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtAuthenticationVerificationFilter extends BasicAuthenticationFilter {
+
+  private final SecurityConstants securityConstants;
+
+  public JwtAuthenticationVerificationFilter(AuthenticationManager authenticationManager,
+                                             SecurityConstants securityConstants) {
+    super(authenticationManager);
+    this.securityConstants = securityConstants;
+  }
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request,
+                                  HttpServletResponse response,
+                                  FilterChain chain) throws IOException, ServletException {
+    try {
+      var header = request.getHeader(securityConstants.getJwtHeaderName());
+
+      if (header != null && header.startsWith(securityConstants.getJwtHeaderPrefix())) {
+        var authToken = getAuthenticationToken(request);
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+        log.debug("Auth success.");
+      }
+      chain.doFilter(request, response);
+    } catch (TokenExpiredException ex) {
+      log.debug("Expired token");
+      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+      response.getWriter().write("{\"error\":\"token expired\"}");
+    }
+  }
+
+  private UsernamePasswordAuthenticationToken getAuthenticationToken(HttpServletRequest request) {
+    var token = request.getHeader(securityConstants.getJwtHeaderName());
+    if (token == null) {
+      return null;
+    }
+
+    var jwt = JWT.require(Algorithm.HMAC512(securityConstants.getJwtSecret()))
+        .build()
+        .verify(token.replace(securityConstants.getJwtHeaderPrefix(), ""));
+
+    var subject = jwt.getSubject();
+
+    if (subject == null) {
+      return null;
+    }
+
+    var authorities = jwt.getClaim(securityConstants.getAuthorityClaimKey())
+        .asList(String.class)
+        .stream()
+        .map(SimpleGrantedAuthority::new)
+        .collect(Collectors.toList());
+
+    var userId = jwt.getClaim(securityConstants.getUserIdClaimKey()).asString();
+
+    var authenticationToken = new UsernamePasswordAuthenticationToken(subject, null, authorities);
+    authenticationToken.setDetails(userId);
+
+    return authenticationToken;
+  }
+}

--- a/src/main/java/com/ss/utopia/customer/security/SecurityConfig.java
+++ b/src/main/java/com/ss/utopia/customer/security/SecurityConfig.java
@@ -1,0 +1,47 @@
+package com.ss.utopia.customer.security;
+
+import com.ss.utopia.customer.controller.EndpointConstants;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.web.cors.CorsUtils;
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+@RequiredArgsConstructor
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+  private final SecurityConstants securityConstants;
+
+  @Override
+  protected void configure(HttpSecurity http) throws Exception {
+    http
+        .cors().and().csrf().disable()
+        .authorizeRequests()
+        .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
+        .requestMatchers(CorsUtils::isCorsRequest).permitAll()
+        // permit all to allow unauthenticated creation
+        .antMatchers(HttpMethod.POST, EndpointConstants.API_V_0_1_CUSTOMERS).permitAll()
+        .anyRequest().authenticated()
+        .and()
+        .addFilter(new JwtAuthenticationVerificationFilter(authenticationManagerBean(),
+                                                           securityConstants))
+        .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+    ;
+  }
+
+  @Bean
+  @Override
+  public AuthenticationManager authenticationManagerBean() throws Exception {
+    return super.authenticationManagerBean();
+  }
+}
+

--- a/src/main/java/com/ss/utopia/customer/security/SecurityConstants.java
+++ b/src/main/java/com/ss/utopia/customer/security/SecurityConstants.java
@@ -1,0 +1,30 @@
+package com.ss.utopia.customer.security;
+
+import java.util.Date;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "com.ss.utopia.auth", ignoreUnknownFields = false)
+public class SecurityConstants {
+
+  private String endpoint;
+  private String jwtSecret;
+  private String jwtHeaderName;
+  private String jwtHeaderPrefix;
+  private String jwtIssuer;
+  private long jwtExpirationDuration;
+  private String authorityClaimKey;
+  private String userIdClaimKey;
+
+  public void setJwtExpirationDuration(String jwtExpirationDuration) {
+    this.jwtExpirationDuration = Long.parseLong(jwtExpirationDuration.replaceAll("_", ""));
+  }
+
+  public Date getExpiresAt() {
+    //todo possible concern with different timezones between services?
+    return new Date(System.currentTimeMillis() + jwtExpirationDuration);
+  }
+}

--- a/src/main/java/com/ss/utopia/customer/security/UserRole.java
+++ b/src/main/java/com/ss/utopia/customer/security/UserRole.java
@@ -1,0 +1,23 @@
+package com.ss.utopia.customer.security;
+
+public enum UserRole {
+  DEFAULT("ROLE_DEFAULT"),
+  CUSTOMER("ROLE_CUSTOMER"),
+  TRAVEL_AGENT("ROLE_TRAVEL_AGENT"),
+  EMPLOYEE("ROLE_EMPLOYEE"),
+  ADMIN("ROLE_ADMIN");
+
+  private final String roleName;
+
+  UserRole(String roleName) {
+    this.roleName = roleName;
+  }
+
+  public String getRole() {
+    return roleName;
+  }
+
+  public String getRoleName() {
+    return roleName.replace("ROLE_", "");
+  }
+}

--- a/src/main/java/com/ss/utopia/customer/security/permissions/CreateCustomerPermission.java
+++ b/src/main/java/com/ss/utopia/customer/security/permissions/CreateCustomerPermission.java
@@ -1,0 +1,33 @@
+package com.ss.utopia.customer.security.permissions;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+/**
+ * Permissions for creating a new Customer entity.
+ * <p>
+ * ALLOW:
+ * <ul>
+ *   <li>ADMIN</li>
+ *   <li>TRAVEL_AGENT</li>
+ *   <li>EMPLOYEE</li>
+ *   <li>UNAUTHENTICATED (ie for a customer creating a new account)</li>
+ * </ul>
+ * <p>
+ * <p>
+ * DENY:
+ * <ul>
+ *   <li>DEFAULT</li>
+ *   <li>CUSTOMER</li>
+ * </ul>
+ * <p>
+ * An example of a deny is a customer attempting to create a new record.
+ * This should be denied because they already have an existing record.
+ * They should be logged out to create a new, different record.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("hasAnyRole('ADMIN','EMPLOYEE','TRAVEL_AGENT') OR NOT isAuthenticated()")
+public @interface CreateCustomerPermission {
+
+}

--- a/src/main/java/com/ss/utopia/customer/security/permissions/DeleteCustomerByIdPermission.java
+++ b/src/main/java/com/ss/utopia/customer/security/permissions/DeleteCustomerByIdPermission.java
@@ -1,0 +1,13 @@
+package com.ss.utopia.customer.security.permissions;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("hasRole('ADMIN')"
+    + " OR hasRole('CUSTOMER')"
+    + " AND @customerAuthenticationManager.customerIdMatches(authentication, #customerId)")
+public @interface DeleteCustomerByIdPermission {
+
+}

--- a/src/main/java/com/ss/utopia/customer/security/permissions/GetCustomerByEmailPermission.java
+++ b/src/main/java/com/ss/utopia/customer/security/permissions/GetCustomerByEmailPermission.java
@@ -1,0 +1,12 @@
+package com.ss.utopia.customer.security.permissions;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("hasAnyRole('ADMIN', 'TRAVEL_AGENT', 'EMPLOYEE') "
+    + "OR hasRole('CUSTOMER') "
+    + "AND @customerAuthenticationManager.customerEmailMatches(authentication, #email)")
+public @interface GetCustomerByEmailPermission {
+}

--- a/src/main/java/com/ss/utopia/customer/security/permissions/GetCustomerByIdPermission.java
+++ b/src/main/java/com/ss/utopia/customer/security/permissions/GetCustomerByIdPermission.java
@@ -1,0 +1,12 @@
+package com.ss.utopia.customer.security.permissions;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("hasAnyRole('ADMIN', 'TRAVEL_AGENT', 'EMPLOYEE')"
+    + " OR hasRole('CUSTOMER')"
+    + " AND @customerAuthenticationManager.customerIdMatches(authentication, #customerId)")
+public @interface GetCustomerByIdPermission {
+}

--- a/src/main/java/com/ss/utopia/customer/security/permissions/UpdateLoyaltyPermission.java
+++ b/src/main/java/com/ss/utopia/customer/security/permissions/UpdateLoyaltyPermission.java
@@ -1,0 +1,11 @@
+package com.ss.utopia.customer.security.permissions;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("hasAnyRole('ADMIN','EMPLOYEE','TRAVEL_AGENT')")
+public @interface UpdateLoyaltyPermission {
+
+}

--- a/src/main/java/com/ss/utopia/customer/service/CustomerService.java
+++ b/src/main/java/com/ss/utopia/customer/service/CustomerService.java
@@ -14,6 +14,8 @@ public interface CustomerService {
 
   Customer getCustomerById(UUID id);
 
+  Customer getCustomerByEmail(String email);
+
   Customer createNewCustomer(CreateCustomerDto customerDto);
 
   void removeCustomerById(UUID id);

--- a/src/main/java/com/ss/utopia/customer/service/CustomerService.java
+++ b/src/main/java/com/ss/utopia/customer/service/CustomerService.java
@@ -3,6 +3,7 @@ package com.ss.utopia.customer.service;
 import com.ss.utopia.customer.dto.CreateCustomerDto;
 import com.ss.utopia.customer.dto.PaymentMethodDto;
 import com.ss.utopia.customer.dto.UpdateCustomerDto;
+import com.ss.utopia.customer.dto.UpdateCustomerLoyaltyDto;
 import com.ss.utopia.customer.entity.Customer;
 import com.ss.utopia.customer.entity.PaymentMethod;
 import java.util.List;
@@ -31,4 +32,6 @@ public interface CustomerService {
   PaymentMethod getPaymentMethod(UUID customerId, Long paymentId);
 
   Integer getCustomerLoyaltyPoints(UUID id);
+  
+  void updateCustomerLoyaltyPoints(UUID id, UpdateCustomerLoyaltyDto customerLoyaltyDto);
 }

--- a/src/main/java/com/ss/utopia/customer/service/CustomerServiceImpl.java
+++ b/src/main/java/com/ss/utopia/customer/service/CustomerServiceImpl.java
@@ -47,6 +47,13 @@ public class CustomerServiceImpl implements CustomerService {
         .orElseThrow(() -> new NoSuchCustomerException(id));
   }
 
+  @Override
+  public Customer getCustomerByEmail(String email) {
+    notNull(email);
+    return repository.findByEmail(email)
+        .orElseThrow(() -> new NoSuchCustomerException(email));
+  }
+
   /**
    * Creates a new {@link Customer} record.
    * <p>

--- a/src/test/java/com/ss/utopia/customer/controller/CustomerControllerSecurityTests.java
+++ b/src/test/java/com/ss/utopia/customer/controller/CustomerControllerSecurityTests.java
@@ -1,0 +1,565 @@
+package com.ss.utopia.customer.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ss.utopia.customer.dto.CreateCustomerDto;
+import com.ss.utopia.customer.dto.PaymentMethodDto;
+import com.ss.utopia.customer.dto.UpdateCustomerDto;
+import com.ss.utopia.customer.entity.Address;
+import com.ss.utopia.customer.entity.Customer;
+import com.ss.utopia.customer.entity.PaymentMethod;
+import com.ss.utopia.customer.security.SecurityConstants;
+import com.ss.utopia.customer.service.CustomerService;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest
+public class CustomerControllerSecurityTests {
+
+  final Date expiresAt = Date.from(LocalDateTime.now().plusDays(1).toInstant(ZoneOffset.UTC));
+  @Autowired
+  WebApplicationContext wac;
+  @MockBean
+  SecurityConstants securityConstants;
+
+  @MockBean
+  CustomerService customerService;
+  MockMvc mvc;
+
+  PaymentMethod mockPaymentMethod = PaymentMethod.builder()
+      .id(1L)
+      .ownerId(UUID.fromString("a4a9feca-bfe7-4c45-8319-7cb6cdd359db"))
+      .accountNum("123456789")
+      .notes("test test")
+      .build();
+
+  PaymentMethodDto mockPaymentDto = PaymentMethodDto.builder()
+      .accountNum(mockPaymentMethod.getAccountNum())
+      .notes(mockPaymentMethod.getNotes())
+      .build();
+
+  Customer mockCustomer = Customer.builder()
+      .id(UUID.fromString("a4a9feca-bfe7-4c45-8319-7cb6cdd359db"))
+      .firstName("Eddy")
+      .lastName("Grant")
+      .email("eddy_grant@test.com")
+      .phoneNumber("420-420-6969")
+      .addresses(Set.of(Address.builder()
+                            .line1("2 Electric Ave.")
+                            .line2("Suite HI-R")
+                            .city("Las Vegas")
+                            .state("NV")
+                            .zipcode("69420")
+                            .build()))
+      .paymentMethods(new HashSet<>())
+      .build();
+
+  CreateCustomerDto mockCreateDto = CreateCustomerDto.builder()
+      .id(mockCustomer.getId())
+      .firstName(mockCustomer.getFirstName())
+      .lastName(mockCustomer.getLastName())
+      .email(mockCustomer.getEmail())
+      .phoneNumber(mockCustomer.getPhoneNumber())
+      .addrLine1("2 Electric Ave.")
+      .addrLine2("Suite HI-R")
+      .city("Las Vegas")
+      .state("NV")
+      .zipcode("69420")
+      .build();
+
+  UpdateCustomerDto mockUpdateDto = UpdateCustomerDto.builder()
+      .firstName(mockCustomer.getFirstName())
+      .lastName(mockCustomer.getLastName())
+      .email(mockCustomer.getEmail())
+      .phoneNumber(mockCustomer.getPhoneNumber())
+      .loyaltyPoints(mockCustomer.getLoyaltyPoints())
+      .addrLine1(mockCreateDto.getAddrLine1())
+      .addrLine2(mockCreateDto.getAddrLine2())
+      .city(mockCreateDto.getCity())
+      .state(mockCreateDto.getState())
+      .zipcode(mockCreateDto.getZipcode())
+      .build();
+
+  @BeforeEach
+  void beforeEach() {
+    if (mockCustomer.getPaymentMethods().isEmpty()) {
+      mockCustomer.getPaymentMethods().add(mockPaymentMethod);
+    }
+
+    mvc = MockMvcBuilders
+        .webAppContextSetup(wac)
+        .apply(springSecurity())
+        .build();
+
+    when(securityConstants.getEndpoint()).thenReturn("/authenticate");
+    when(securityConstants.getJwtIssuer()).thenReturn("test-issuer");
+    when(securityConstants.getExpiresAt()).thenReturn(expiresAt);
+    when(securityConstants.getJwtSecret()).thenReturn("superSecret");
+    when(securityConstants.getUserIdClaimKey()).thenReturn("userId");
+    when(securityConstants.getAuthorityClaimKey()).thenReturn("Authorities");
+    when(securityConstants.getJwtHeaderName()).thenReturn("Authorization");
+    when(securityConstants.getJwtHeaderPrefix()).thenReturn("Bearer ");
+
+    when(customerService.getCustomerById(mockCustomer.getId()))
+        .thenReturn(mockCustomer);
+
+    when(customerService.getAllCustomers())
+        .thenReturn(List.of(mockCustomer));
+
+    when(customerService.getCustomerByEmail(mockCustomer.getEmail()))
+        .thenReturn(mockCustomer);
+
+    when(customerService.getCustomerLoyaltyPoints(mockCustomer.getId()))
+        .thenReturn(mockCustomer.getLoyaltyPoints());
+
+    when((customerService.createNewCustomer(mockCreateDto)))
+        .thenReturn(mockCustomer);
+
+    when(customerService.updateCustomer(mockCustomer.getId(), mockUpdateDto))
+        .thenReturn(mockCustomer);
+
+    when(customerService.getPaymentMethod(mockCustomer.getId(), mockPaymentMethod.getId()))
+        .thenReturn(mockPaymentMethod);
+
+    when(customerService.addPaymentMethod(mockCustomer.getId(), mockPaymentDto))
+        .thenReturn(mockPaymentMethod.getId());
+  }
+
+  String getJwt(MockUser mockUser) {
+    var jwt = JWT.create()
+        .withSubject(mockUser.email)
+        .withIssuer(securityConstants.getJwtIssuer())
+        .withClaim(securityConstants.getUserIdClaimKey(), mockUser.id)
+        .withClaim(securityConstants.getAuthorityClaimKey(), List.of(mockUser.getAuthority()))
+        .withExpiresAt(expiresAt)
+        .sign(Algorithm.HMAC512(securityConstants.getJwtSecret()));
+    return "Bearer " + jwt;
+  }
+
+  @Test
+  void test_getAllCustomers_CanOnlyBePerformedByADMIN() throws Exception {
+    mvc
+        .perform(
+            get(EndpointConstants.API_V_0_1_CUSTOMERS)
+                .header("Authorization", getJwt(MockUser.ADMIN)))
+        .andExpect(status().isOk());
+
+    var unauthed = List.of(MockUser.DEFAULT,
+                           MockUser.MATCH_CUSTOMER,
+                           MockUser.UNMATCH_CUSTOMER,
+                           MockUser.EMPLOYEE,
+                           MockUser.TRAVEL_AGENT);
+
+    for (var user : unauthed) {
+      mvc
+          .perform(
+              get(EndpointConstants.API_V_0_1_CUSTOMERS)
+                  .header("Authorization", getJwt(user)))
+          .andExpect(status().isForbidden());
+    }
+
+    mvc
+        .perform(
+            get(EndpointConstants.API_V_0_1_CUSTOMERS))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void test_getCustomerById_CanBePerformedByAuthedUsersOrOwningCustomerOnly() throws Exception {
+    var alwaysAuthed = List.of(MockUser.ADMIN,
+                               MockUser.TRAVEL_AGENT,
+                               MockUser.EMPLOYEE,
+                               MockUser.MATCH_CUSTOMER);
+    for (var user : alwaysAuthed) {
+      mvc
+          .perform(
+              get(EndpointConstants.API_V_0_1_CUSTOMERS + "/" + mockCustomer.getId())
+                  .header("Authorization", getJwt(user)))
+          .andExpect(status().isOk());
+    }
+
+    var unauthed = List.of(MockUser.DEFAULT, MockUser.UNMATCH_CUSTOMER);
+
+    for (var user : unauthed) {
+      mvc
+          .perform(
+              get(EndpointConstants.API_V_0_1_CUSTOMERS + "/" + mockCustomer.getId())
+                  .header("Authorization", getJwt(user)))
+          .andExpect(status().isForbidden());
+    }
+
+    mvc
+        .perform(
+            get(EndpointConstants.API_V_0_1_CUSTOMERS + "/" + mockCustomer.getId()))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void test_getCustomerByEmail_CanBePerformedByAuthedUsersOrOwningCustomerOnly() throws Exception {
+    var alwaysAuthed = List.of(MockUser.ADMIN,
+                               MockUser.TRAVEL_AGENT,
+                               MockUser.EMPLOYEE,
+                               MockUser.MATCH_CUSTOMER);
+    for (var user : alwaysAuthed) {
+      mvc
+          .perform(
+              get(EndpointConstants.API_V_0_1_CUSTOMERS + "/email/" + mockCustomer.getEmail())
+                  .header("Authorization", getJwt(user)))
+          .andExpect(status().isOk());
+    }
+
+    var unauthed = List.of(MockUser.DEFAULT, MockUser.UNMATCH_CUSTOMER);
+
+    for (var user : unauthed) {
+      mvc
+          .perform(
+              get(EndpointConstants.API_V_0_1_CUSTOMERS + "/email/" + mockCustomer.getEmail())
+                  .header("Authorization", getJwt(user)))
+          .andExpect(status().isForbidden());
+    }
+
+    mvc
+        .perform(
+            get(EndpointConstants.API_V_0_1_CUSTOMERS + "/email/" + mockCustomer.getEmail()))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void test_getCustomerLoyaltyPoints_CanBePerformedByAuthedUserOrOwningCustomerOnly()
+      throws Exception {
+    var alwaysAuthed = List.of(MockUser.ADMIN,
+                               MockUser.TRAVEL_AGENT,
+                               MockUser.EMPLOYEE,
+                               MockUser.MATCH_CUSTOMER);
+    for (var user : alwaysAuthed) {
+      mvc
+          .perform(
+              get(EndpointConstants.API_V_0_1_CUSTOMERS + "/loyalty/" + mockCustomer.getId())
+                  .header("Authorization", getJwt(user)))
+          .andExpect(status().isOk());
+    }
+
+    var unauthed = List.of(MockUser.DEFAULT, MockUser.UNMATCH_CUSTOMER);
+
+    for (var user : unauthed) {
+      mvc
+          .perform(
+              get(EndpointConstants.API_V_0_1_CUSTOMERS + "/loyalty/" + mockCustomer.getId())
+                  .header("Authorization", getJwt(user)))
+          .andExpect(status().isForbidden());
+    }
+
+    // also check for not authenticated
+    mvc
+        .perform(
+            get(EndpointConstants.API_V_0_1_CUSTOMERS + "/loyalty/" + mockCustomer.getId()))
+        .andExpect(status().isForbidden());
+  }
+
+  /**
+   * Should Allow:
+   * <ul>
+   *   <li>ADMIN</li>
+   *   <li>TRAVEL_AGENT</li>
+   *   <li>EMPLOYEE</li>
+   * </ul>
+   *
+   * CUSTOMER or DEFAULT should NOT be allowed
+   * BUT any UNAUTHENTICATED usage is permitted (ie for a customer creating a new account).
+   */
+  @Test
+  void test_createNewCustomer_CanBePerformedCorrectly() throws Exception {
+    var alwaysAuthed = List.of(MockUser.ADMIN,
+                               MockUser.TRAVEL_AGENT,
+                               MockUser.EMPLOYEE);
+    var mockDtoAsJson = new ObjectMapper().writeValueAsString(mockCreateDto);
+    for (var user : alwaysAuthed) {
+      mvc.perform(
+          post(EndpointConstants.API_V_0_1_CUSTOMERS)
+              .header("Authorization", getJwt(user))
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(mockDtoAsJson))
+          .andExpect(status().isCreated());
+    }
+
+    var unauthed = List.of(MockUser.DEFAULT,
+                           MockUser.MATCH_CUSTOMER,
+                           MockUser.UNMATCH_CUSTOMER);
+
+    for (var user : unauthed) {
+      mvc.perform(
+          post(EndpointConstants.API_V_0_1_CUSTOMERS)
+              .header("Authorization", getJwt(user))
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(mockDtoAsJson))
+          .andExpect(status().isForbidden());
+    }
+
+    // also check for not authenticated
+    mvc.perform(
+        post(EndpointConstants.API_V_0_1_CUSTOMERS)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(mockDtoAsJson))
+        .andExpect(status().isCreated());
+  }
+
+  @Test
+  void test_updateExistingCustomer_CanBePerformedByAuthedUserOrOwningCustomerOnly()
+      throws Exception {
+    var alwaysAuthed = List.of(MockUser.ADMIN,
+                               MockUser.TRAVEL_AGENT,
+                               MockUser.EMPLOYEE,
+                               MockUser.MATCH_CUSTOMER);
+    var mockDtoAsJson = new ObjectMapper().writeValueAsString(mockUpdateDto);
+
+    for (var user : alwaysAuthed) {
+      mvc.perform(
+          put(EndpointConstants.API_V_0_1_CUSTOMERS + "/" + mockCustomer.getId())
+              .header("Authorization", getJwt(user))
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(mockDtoAsJson))
+          .andExpect(status().isNoContent());
+    }
+
+    var unauthed = List.of(MockUser.DEFAULT, MockUser.UNMATCH_CUSTOMER);
+    for (var user : unauthed) {
+      mvc.perform(
+          put(EndpointConstants.API_V_0_1_CUSTOMERS + "/" + mockCustomer.getId())
+              .header("Authorization", getJwt(user))
+              .contentType(MediaType.APPLICATION_JSON)
+              .content(mockDtoAsJson))
+          .andExpect(status().isForbidden());
+    }
+
+    mvc.perform(
+        put(EndpointConstants.API_V_0_1_CUSTOMERS + "/" + mockCustomer.getId())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(mockDtoAsJson))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void test_deleteCustomer_CanOnlyBePerformedByADMINOrOwningCustomer() throws Exception {
+    var alwaysAuthed = List.of(MockUser.ADMIN, MockUser.MATCH_CUSTOMER);
+
+    for (var user : alwaysAuthed) {
+      mvc.perform(
+          delete(EndpointConstants.API_V_0_1_CUSTOMERS + "/" + mockCustomer.getId())
+              .header("Authorization", getJwt(user)))
+          .andExpect(status().isNoContent());
+    }
+
+    var unauthed = List.of(MockUser.DEFAULT,
+                           MockUser.UNMATCH_CUSTOMER,
+                           MockUser.TRAVEL_AGENT,
+                           MockUser.EMPLOYEE);
+
+    for (var user : unauthed) {
+      mvc.perform(
+          delete(EndpointConstants.API_V_0_1_CUSTOMERS + "/" + mockCustomer.getId())
+              .header("Authorization", getJwt(user)))
+          .andExpect(status().isForbidden());
+    }
+
+    mvc.perform(
+        delete(EndpointConstants.API_V_0_1_CUSTOMERS + "/" + mockCustomer.getId()))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void test_getPaymentMethod_CanBePerformedByAuthedUsersOrOwningCustomerOnly() throws Exception {
+    var alwaysAuthed = List.of(MockUser.ADMIN,
+                               MockUser.TRAVEL_AGENT,
+                               MockUser.EMPLOYEE,
+                               MockUser.MATCH_CUSTOMER);
+    var url =
+        EndpointConstants.API_V_0_1_CUSTOMERS + "/" + mockCustomer.getId() + "/payment-method/1";
+    for (var user : alwaysAuthed) {
+      mvc
+          .perform(
+              get(url)
+                  .header("Authorization", getJwt(user)))
+          .andExpect(status().isOk());
+    }
+
+    var unauthed = List.of(MockUser.DEFAULT, MockUser.UNMATCH_CUSTOMER);
+
+    for (var user : unauthed) {
+      mvc
+          .perform(
+              get(url)
+                  .header("Authorization", getJwt(user)))
+          .andExpect(status().isForbidden());
+    }
+
+    mvc
+        .perform(
+            get(url))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void test_addPaymentMethod_CanBePerformedByAuthedUsersOrOwningCustomerOnly() throws Exception {
+    var alwaysAuthed = List.of(MockUser.ADMIN,
+                               MockUser.TRAVEL_AGENT,
+                               MockUser.EMPLOYEE,
+                               MockUser.MATCH_CUSTOMER);
+    var url =
+        EndpointConstants.API_V_0_1_CUSTOMERS + "/" + mockCustomer.getId() + "/payment-method";
+    var content = new ObjectMapper().writeValueAsString(mockPaymentDto);
+
+    for (var user : alwaysAuthed) {
+      mvc
+          .perform(
+              post(url)
+                  .header("Authorization", getJwt(user))
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(content))
+          .andExpect(status().isCreated());
+    }
+
+    var unauthed = List.of(MockUser.DEFAULT, MockUser.UNMATCH_CUSTOMER);
+
+    for (var user : unauthed) {
+      mvc
+          .perform(
+              post(url)
+                  .header("Authorization", getJwt(user))
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(content))
+          .andExpect(status().isForbidden());
+    }
+
+    mvc
+        .perform(
+            post(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void test_updatePaymentMethod_CanBePerformedByAuthedUsersOrOwningCustomerOnly() throws Exception {
+    var alwaysAuthed = List.of(MockUser.ADMIN,
+                               MockUser.TRAVEL_AGENT,
+                               MockUser.EMPLOYEE,
+                               MockUser.MATCH_CUSTOMER);
+    var url =
+        EndpointConstants.API_V_0_1_CUSTOMERS + "/" + mockCustomer.getId() + "/payment-method/"
+            + mockPaymentMethod.getId();
+    var content = new ObjectMapper().writeValueAsString(mockPaymentDto);
+
+    for (var user : alwaysAuthed) {
+      mvc
+          .perform(
+              put(url)
+                  .header("Authorization", getJwt(user))
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(content))
+          .andExpect(status().isNoContent());
+    }
+
+    var unauthed = List.of(MockUser.DEFAULT, MockUser.UNMATCH_CUSTOMER);
+
+    for (var user : unauthed) {
+      mvc
+          .perform(
+              put(url)
+                  .header("Authorization", getJwt(user))
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(content))
+          .andExpect(status().isForbidden());
+    }
+
+    mvc
+        .perform(
+            put(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void test_removePaymentMethod_CanOnlyBePerformedByADMINOrOwningCustomer() throws Exception {
+    var alwaysAuthed = List.of(MockUser.ADMIN,
+                               MockUser.MATCH_CUSTOMER);
+    var url =
+        EndpointConstants.API_V_0_1_CUSTOMERS + "/" + mockCustomer.getId() + "/payment-method/"
+            + mockPaymentMethod.getId();
+
+    for (var user : alwaysAuthed) {
+      mvc
+          .perform(
+              delete(url)
+                  .header("Authorization", getJwt(user)))
+          .andExpect(status().isNoContent());
+    }
+
+    var unauthed = List.of(MockUser.DEFAULT,
+                           MockUser.TRAVEL_AGENT,
+                           MockUser.EMPLOYEE,
+                           MockUser.UNMATCH_CUSTOMER);
+
+    for (var user : unauthed) {
+      mvc
+          .perform(
+              delete(url)
+                  .header("Authorization", getJwt(user)))
+          .andExpect(status().isForbidden());
+    }
+
+    mvc
+        .perform(
+            delete(url))
+        .andExpect(status().isForbidden());
+  }
+
+  enum MockUser {
+    DEFAULT("default@test.com", "ROLE_DEFAULT", UUID.randomUUID().toString()),
+    MATCH_CUSTOMER("eddy_grant@test.com", "ROLE_CUSTOMER", "a4a9feca-bfe7-4c45-8319-7cb6cdd359db"),
+    UNMATCH_CUSTOMER("someOtherCustomer@test.com", "ROLE_CUSTOMER", UUID.randomUUID().toString()),
+    EMPLOYEE("employee@test.com", "ROLE_EMPLOYEE", UUID.randomUUID().toString()),
+    TRAVEL_AGENT("travel_agent@test.com", "ROLE_TRAVEL_AGENT", UUID.randomUUID().toString()),
+    ADMIN("admin@test.com", "ROLE_ADMIN", UUID.randomUUID().toString());
+
+
+    final String email;
+    final GrantedAuthority grantedAuthority;
+    final String id;
+
+    MockUser(String email, String grantedAuthority, String id) {
+      this.email = email;
+      this.grantedAuthority = new SimpleGrantedAuthority(grantedAuthority);
+      this.id = id;
+    }
+
+    public String getAuthority() {
+      return grantedAuthority.getAuthority();
+    }
+  }
+}

--- a/src/test/java/com/ss/utopia/customer/service/CustomerServiceImplUnitTest.java
+++ b/src/test/java/com/ss/utopia/customer/service/CustomerServiceImplUnitTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import com.ss.utopia.customer.dto.CreateCustomerDto;
 import com.ss.utopia.customer.dto.UpdateCustomerDto;
+import com.ss.utopia.customer.dto.UpdateCustomerLoyaltyDto;
 import com.ss.utopia.customer.entity.Address;
 import com.ss.utopia.customer.entity.Customer;
 import com.ss.utopia.customer.entity.PaymentMethod;
@@ -101,7 +102,6 @@ class CustomerServiceImplUnitTest {
         .firstName(secondCustomer.getFirstName())
         .lastName(secondCustomer.getLastName())
         .email(secondCustomer.getEmail())
-        .loyaltyPoints(secondCustomer.getLoyaltyPoints())
         .addrLine1("456 Strawberry Ln")
         .addrLine2(null)
         .city("Las Vegas")
@@ -182,6 +182,18 @@ class CustomerServiceImplUnitTest {
                  () -> service.getCustomerLoyaltyPoints(UUID.fromString("-1")));
     assertThrows(IllegalArgumentException.class,
                  () -> service.getCustomerLoyaltyPoints(UUID.fromString("0")));
+  }
+  
+  @Test
+  void test_updateCustomerLoyaltyPoints_ThrowsExceptionOnNegativeValue() {
+	  var mockUpdateDto = UpdateCustomerLoyaltyDto.builder()
+			  				.increment(false)
+			  				.pointsToChange(1000)
+			  				.build();
+	  when(repository.findById(firstCustomerId)).thenReturn(Optional.of(firstCustomer));
+	  
+	  assertThrows(IllegalStateException.class,
+			  () -> service.updateCustomerLoyaltyPoints(firstCustomerId, mockUpdateDto));
   }
 
   @Test

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,4 +1,6 @@
 spring.datasource.url=jdbc:h2:mem:testdb
 spring.datasource.driverClassName=org.h2.Driver
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create-drop
+#spring.jpa.show-sql=true
+#spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
In line with the frontend changes to show loyalty points in the profile, [see here](https://github.com/jms-smoothstack-utopia/ss-utopia-customers/pull/1), this change prevents customers from updating their own loyalty points and adds code/a DTO for updating points from elsewhere in the application.

This also pulls in security-related code from SSUTO-68-Security.