### PR TITLE
SSUTO-86 TASK: Deprecate Eureka Service Discovery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,11 +53,6 @@
 
     <dependency>
       <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-config</artifactId>
     </dependency>
 
@@ -129,7 +124,14 @@
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-maven-plugin</artifactId>
       <version>${spotbugs.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-simple</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
+
   </dependencies>
 
   <dependencyManagement>

--- a/src/main/java/com/ss/utopia/customer/CustomerApplication.java
+++ b/src/main/java/com/ss/utopia/customer/CustomerApplication.java
@@ -1,14 +1,8 @@
 package com.ss.utopia.customer;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.commons.util.InetUtils;
-import org.springframework.cloud.netflix.eureka.EurekaInstanceConfigBean;
 import org.springframework.cloud.openfeign.EnableFeignClients;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Profile;
 
 @EnableFeignClients
 @SpringBootApplication
@@ -16,16 +10,5 @@ public class CustomerApplication {
 
   public static void main(String[] args) {
     SpringApplication.run(CustomerApplication.class, args);
-  }
-
-  @Profile("ecs")
-  @Bean
-  public EurekaInstanceConfigBean eurekaInstanceConfigBean(InetUtils inetUtils)
-      throws UnknownHostException {
-    var config = new EurekaInstanceConfigBean(inetUtils);
-    config.setIpAddress(InetAddress.getLocalHost().getHostAddress());
-    config.setNonSecurePort(8081);
-    config.setPreferIpAddress(true);
-    return config;
   }
 }

--- a/src/main/java/com/ss/utopia/customer/client/AccountsClient.java
+++ b/src/main/java/com/ss/utopia/customer/client/AccountsClient.java
@@ -6,6 +6,7 @@ import com.ss.utopia.customer.dto.CreateUserAccountDto;
 import com.ss.utopia.customer.dto.DeleteAccountDto;
 import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,7 +16,8 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 
-@FeignClient("utopia-auth-service")
+@Profile("ecs")
+@FeignClient(name = "utopia-auth-service", url = "http://utopia-auth-service:8089")
 public interface AccountsClient {
 
   @PostMapping(value = "/login")
@@ -24,20 +26,20 @@ public interface AccountsClient {
   @PutMapping(value = EndpointConstants.API_V_0_1_ACCOUNTS + "/customer/{customerId}",
       consumes = MediaType.TEXT_PLAIN_VALUE)
   ResponseEntity<Void> updateCustomerEmail(@RequestHeader(value = "Authorization")
-                                        String authorizationHeader,
-                                        @PathVariable UUID customerId,
-                                        @RequestBody String newEmail);
+                                               String authorizationHeader,
+                                           @PathVariable UUID customerId,
+                                           @RequestBody String newEmail);
 
   @PostMapping(EndpointConstants.API_V_0_1_ACCOUNTS)
   ResponseEntity<UUID> createNewAccount(@RequestBody CreateUserAccountDto dto);
 
   @DeleteMapping(EndpointConstants.API_V_0_1_ACCOUNTS + "/customer")
   ResponseEntity<Void> initiateCustomerDeletion(@RequestHeader(value = "Authorization")
-                                             String authorizationHeader,
-                                             @RequestBody DeleteAccountDto deleteAccountDto);
+                                                    String authorizationHeader,
+                                                @RequestBody DeleteAccountDto deleteAccountDto);
 
   @DeleteMapping(EndpointConstants.API_V_0_1_ACCOUNTS + "/customer/{confirmationToken}")
   ResponseEntity<UUID> completeCustomerDeletion(@RequestHeader(value = "Authorization")
-                                                String authorizationHeader,
+                                                    String authorizationHeader,
                                                 @PathVariable UUID confirmationToken);
 }

--- a/src/main/java/com/ss/utopia/customer/client/AccountsClientLocal.java
+++ b/src/main/java/com/ss/utopia/customer/client/AccountsClientLocal.java
@@ -1,0 +1,10 @@
+package com.ss.utopia.customer.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.context.annotation.Profile;
+
+@Profile("local")
+@FeignClient(name = "utopia-auth-service", url = "http://localhost:8089")
+public interface AccountsClientLocal extends AccountsClient {
+
+}

--- a/src/main/resources/application-ecs.properties
+++ b/src/main/resources/application-ecs.properties
@@ -1,0 +1,2 @@
+spring.config.import=configserver:
+spring.cloud.config.uri=http://utopia-config-service:8888

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,2 @@
+spring.config.import=configserver:
+spring.cloud.config.uri=http://localhost:8888

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,3 @@
 spring.application.name=utopia-customers-service
 
-# require configuration from service through Eureka discovery
-spring.config.import=configserver:
-spring.cloud.config.discovery.enabled=true
-spring.cloud.config.discovery.service-id=utopia-config-service
-
 spring.profiles.active=local,local-h2

--- a/src/test/java/com/ss/utopia/customer/CustomerApplicationTests.java
+++ b/src/test/java/com/ss/utopia/customer/CustomerApplicationTests.java
@@ -1,13 +1,18 @@
 package com.ss.utopia.customer;
 
+import com.ss.utopia.customer.client.AccountsClient;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
 class CustomerApplicationTests {
 
+  @MockBean
+  AccountsClient accountsClient;
+  
   @Test
   void contextLoads() {
     assertTrue(true);

--- a/src/test/java/com/ss/utopia/customer/controller/CustomerControllerSecurityTests.java
+++ b/src/test/java/com/ss/utopia/customer/controller/CustomerControllerSecurityTests.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ss.utopia.customer.client.AccountsClient;
 import com.ss.utopia.customer.dto.CreateCustomerDto;
 import com.ss.utopia.customer.dto.DeleteAccountDto;
 import com.ss.utopia.customer.dto.PaymentMethodDto;
@@ -49,6 +50,9 @@ public class CustomerControllerSecurityTests {
   WebApplicationContext wac;
   @MockBean
   SecurityConstants securityConstants;
+
+  @MockBean
+  AccountsClient accountsClient;
 
   @MockBean
   CustomerService customerService;

--- a/src/test/java/com/ss/utopia/customer/controller/CustomerControllerTest.java
+++ b/src/test/java/com/ss/utopia/customer/controller/CustomerControllerTest.java
@@ -15,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ss.utopia.customer.client.AccountsClient;
 import com.ss.utopia.customer.dto.CreateCustomerDto;
 import com.ss.utopia.customer.dto.UpdateCustomerDto;
 import com.ss.utopia.customer.dto.PaymentMethodDto;
@@ -39,6 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -54,6 +56,9 @@ class CustomerControllerTest {
   public static final String CUSTOMER_ENDPOINT = EndpointConstants.API_V_0_1_CUSTOMERS;
   public static final String DEFAULT_PAYMENT_ENDPOINT =
       CUSTOMER_ENDPOINT + "/" + validCustomerId + "/payment-method";
+
+  @MockBean
+  AccountsClient accountsClient;
 
   private final CustomerService customerService = Mockito.mock(CustomerService.class);
   private final DeleteAccountService deleteAccountService = Mockito.mock(DeleteAccountService.class);

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -4,6 +4,3 @@ spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=create-drop
 #spring.jpa.show-sql=true
 #spring.jpa.properties.hibernate.format_sql=true
-
-eureka.client.register-with-eureka=false
-eureka.client.fetch-registry=false


### PR DESCRIPTION
This change commits to using service discovery created by Docker Compose
for ECS deployments. For local development, no service discovery will be
necessary. Instead, we are providing an additional `local` profile for
interacting with the configuration server. As such, the Eureka dependency
has been removed, and the `ecs` profile Bean for handling Eureka has been
removed.

As this service uses a FeignClient for interacting with the AuthService,
an additional client is provided as an extension of the ECS FeignClient
for local development.

This additionally excludes SLF4J bindings from the SpotBugs dependency
which was causing a warning on application boot.